### PR TITLE
Deploy

### DIFF
--- a/deploy_tools/gunicorn-upstart.template.conf
+++ b/deploy_tools/gunicorn-upstart.template.conf
@@ -1,0 +1,14 @@
+description "Gunicorn server for SITENAME"
+
+
+start on net-device-up
+stop on shutdown
+
+respawn
+
+setuid pi
+chdir /home/pi/sites/SITENAME/edupi
+
+exec ../virtualenv/bin/gunicorn \
+     --bind unix:/tmp/SITENAME.socket \
+     edupi.wsgi:application

--- a/deploy_tools/nginx.template.conf
+++ b/deploy_tools/nginx.template.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name SITENAME;
+
+    location /static {
+        alias /home/pi/WEBAPPS/SITENAME/static;
+    }
+
+    location / {
+        proxy_set_header Host $host
+        proxy_pass http://unix:/tmp/SITENAME.socket;
+    }
+}

--- a/edupi/settings.py
+++ b/edupi/settings.py
@@ -62,7 +62,7 @@ WSGI_APPLICATION = 'edupi.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, '../database/db.sqlite3'),
     }
 }
 
@@ -87,7 +87,7 @@ STATIC_URL = '/static/'
 
 TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
 
-STATIC_ROOT = os.path.join(BASE_DIR, "static/")
+STATIC_ROOT = os.path.join(BASE_DIR, "../static/")
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "libs/static"),

--- a/functional_tests/base.py
+++ b/functional_tests/base.py
@@ -1,8 +1,24 @@
+import sys
+
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
 
 
 class FunctionalTest(StaticLiveServerTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        for arg in sys.argv:
+            if 'liveserver' in arg:
+                cls.server_url = 'http://' + arg.split('=')[1]
+                return
+        super().setUpClass()
+        cls.server_url = cls.live_server_url
+
+    @classmethod
+    def tearDown(cls):
+        if cls.server_url == cls.live_server_url:
+            super().tearDownClass()
 
     def setUp(self):
         super().setUp()

--- a/functional_tests/test_cntapp.py
+++ b/functional_tests/test_cntapp.py
@@ -6,13 +6,13 @@ class IndexPageTest(FunctionalTest):
 
     def test_visit_index_page(self):
         # enter into index page
-        self.browser.get(self.live_server_url)
+        self.browser.get(self.server_url)
 
         # checkout the 'get started' link
         link = self.browser.find_element_by_id('id_get_started')
-        self.assertEqual(link.get_attribute(name='href'), self.live_server_url + '/dirs/')
+        self.assertEqual(link.get_attribute(name='href'), self.server_url + '/dirs/')
 
         link.click()
 
         # go to browse the directories
-        self.assertEqual(self.browser.current_url, self.live_server_url + '/dirs/')
+        self.assertEqual(self.browser.current_url, self.server_url + '/dirs/')

--- a/functional_tests/test_custom.py
+++ b/functional_tests/test_custom.py
@@ -16,7 +16,7 @@ class CustomSiteTestCase(FunctionalTest):
 
     def test_create_directories(self):
         # Alice wants to customize the web site, she enters into the custom home page
-        custom_page_url = self.live_server_url + '/custom/'
+        custom_page_url = self.server_url + '/custom/'
         self.browser.get(custom_page_url)
 
         # she is currently in the root dir, it's empty, she has to create a dir here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django==1.7.4
+gunicorn==19.3.0


### PR DESCRIPTION
**Features**

- upstart config templates for gunicorn
- a little hack in functional tests for testing staging server. 

However, when testing the staging server, the database must be reset by hand before and after the test ! This need to be improved by using other tools.