### PR TITLE
Fix custom home page display performance issue

### DIFF
--- a/cntapp/helpers.py
+++ b/cntapp/helpers.py
@@ -1,9 +1,30 @@
-from cntapp.models import Directory
+from cntapp.models import Directory, SubDirRelation
+
+
+def queryset_to_list(query_set):
+    return [d for d in query_set]
+
+
+def get_root_dirs_query():
+    """
+    Directories that has no parent are root directories.
+
+    steps:
+    1. select all parents' id from SubDirRelation.
+    2. exclude directories that have parents
+    """
+    r = SubDirRelation.objects.values('parent').distinct()
+    l = [d['parent'] for d in r]
+
+    # FIXME:
+    # attention: child is a SubDirRelation object that relates to the directory's parent !
+    # then the parent_id point to it's real parent Directory object.
+    # This was a confuse when building the API.
+    return Directory.objects.exclude(child__parent_id__in=l)
 
 
 def get_root_dirs():
-    all_dirs = Directory.objects.all()
-    return [d for d in all_dirs if d.get_parents().count() == 0]
+    return queryset_to_list(get_root_dirs_query())
 
 
 def get_root_dirs_names():

--- a/cntapp/static/cntapp/custom/src/router.js
+++ b/cntapp/static/cntapp/custom/src/router.js
@@ -54,14 +54,7 @@ define([
         },
 
         showRootPage: function () {
-            var dirs = cntapp.collections.directories,
-                that = this;
-            dirs.fetch({
-                reset: true,
-                success: function () {
-                    that.renderToContent(new RootPageView());
-                }
-            })
+            this.renderToContent(new RootPageView());
         },
 
         showDirectoryPage: function (path) {

--- a/cntapp/static/cntapp/custom/src/views/directories.js
+++ b/cntapp/static/cntapp/custom/src/views/directories.js
@@ -41,6 +41,8 @@ define([
             $.getJSON(url)
                 .done(function (data) {
                     that.collection.reset(data);
+                    // update local directory collection.
+                    cntapp.collections.directories.set(data, {remove: false});
                 });
         }
     });


### PR DESCRIPTION
In custom page, every time when go back to "home" after a data modification, we have to wait for a long time. There are mainly two problems:

* Calculation of root directories is poor in performance.
* Each time when go back to "home", the page try to download all directories.